### PR TITLE
First-class commands

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -27,7 +27,6 @@ impl Command for Add {
         }
 
         for file in files {
-            dbg!(&file);
             let data = repo.workspace.read_file(&file).map_err(|err| {
                 repo.index.release_lock().unwrap();
 

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,0 +1,49 @@
+use super::{Command, CommandOpts};
+use crate::{errors::RitError, objects, repository::Repository};
+use std::path::PathBuf;
+
+pub struct Add(pub CommandOpts);
+
+impl Command for Add {
+    fn execute(&mut self) -> Result<(), RitError> {
+        let mut repo = Repository::new(self.0.dir.clone());
+
+        repo.index.load_for_update()?;
+
+        let mut files: Vec<PathBuf> = vec![];
+
+        // TODO: -clone
+        for path in self.0.args.clone() {
+            let path = repo.workspace.expand_path(&path);
+            let path = path.map_err(|err| {
+                repo.index.release_lock().unwrap();
+
+                err
+            })?;
+
+            for file in repo.workspace.list_files(Some(&path)) {
+                files.push(file);
+            }
+        }
+
+        for file in files {
+            dbg!(&file);
+            let data = repo.workspace.read_file(&file).map_err(|err| {
+                repo.index.release_lock().unwrap();
+
+                err
+            })?;
+            let stat = repo.workspace.stat_file(&data);
+
+            let mut blob = objects::Blob::new(data);
+
+            let blob_id = repo.database.store(&mut blob).unwrap();
+
+            repo.index.add(file, blob_id, stat);
+        }
+
+        repo.index.write_updates()?;
+
+        Ok(())
+    }
+}

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -1,7 +1,7 @@
 use super::{Command, CommandOpts};
 use crate::{errors::RitError, id::Id, objects, repository::Repository};
 
-pub struct Commit(pub CommandOpts);
+pub struct Commit(CommandOpts);
 
 impl Commit {
     fn commit<'a>(
@@ -31,6 +31,10 @@ impl Commit {
 }
 
 impl Command for Commit {
+    fn new(opts: CommandOpts) -> Self {
+        Self(opts)
+    }
+
     fn execute(&mut self) -> Result<(), RitError> {
         let mut repo = Repository::new(self.0.dir.clone());
 

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -1,0 +1,61 @@
+use super::{Command, CommandOpts};
+use crate::{errors::RitError, id::Id, objects, repository::Repository};
+
+pub struct Commit(pub CommandOpts);
+
+impl Commit {
+    fn commit<'a>(
+        &'a self,
+        parent_id: &'a Option<String>,
+        root_id: Id,
+        message: &'a str,
+    ) -> objects::Commit {
+        let author = objects::Author::new(&self.0.session.name, &self.0.session.email);
+
+        objects::Commit::new(&parent_id, root_id, author, &message)
+    }
+
+    fn report(&self, parent_id: Option<String>, commit_id: Id, message: String) {
+        let root_part = match parent_id {
+            Some(_) => "",
+            None => "(root-commit) ",
+        };
+
+        println!(
+            "[{}{}] {}",
+            root_part,
+            commit_id.as_str,
+            message.lines().next().unwrap()
+        );
+    }
+}
+
+impl Command for Commit {
+    fn execute(&mut self) -> Result<(), RitError> {
+        let mut repo = Repository::new(self.0.dir.clone());
+
+        repo.index.load()?;
+
+        let entries = repo.index.entries();
+
+        let mut root = objects::Tree::build(entries);
+
+        root.traverse(|tree| {
+            let id = repo.database.store(tree).unwrap();
+            tree.id = Some(id);
+        });
+
+        let root_id = repo.database.store(&mut root)?;
+        let parent_id = repo.refs.read_head();
+
+        let message = self.0.session.read_stdin()?;
+
+        let mut commit = self.commit(&parent_id, root_id, &message);
+        let commit_id = repo.database.store(&mut commit)?;
+        repo.refs.update_head(&commit_id)?;
+
+        self.report(parent_id, commit_id, message);
+
+        Ok(())
+    }
+}

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -2,7 +2,7 @@ use super::{Command, CommandOpts};
 use crate::errors::RitError;
 use std::{fs, path::PathBuf};
 
-pub struct Init(pub CommandOpts);
+pub struct Init(CommandOpts);
 
 impl Init {
     fn git_path(&mut self) -> PathBuf {
@@ -16,6 +16,10 @@ impl Init {
 }
 
 impl Command for Init {
+    fn new(opts: CommandOpts) -> Self {
+        Self(opts)
+    }
+
     fn execute(&mut self) -> Result<(), RitError> {
         let git_path = self.git_path();
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,0 +1,28 @@
+use super::{Command, CommandOpts};
+use crate::errors::RitError;
+use std::{fs, path::PathBuf};
+
+pub struct Init(pub CommandOpts);
+
+impl Init {
+    fn git_path(&mut self) -> PathBuf {
+        self.0
+            .args
+            .get(0)
+            .map(|path| PathBuf::from(path))
+            .unwrap_or(self.0.dir.clone())
+            .join(".git")
+    }
+}
+
+impl Command for Init {
+    fn execute(&mut self) -> Result<(), RitError> {
+        let git_path = self.git_path();
+
+        for dir in &["objects", "refs"] {
+            fs::create_dir_all(git_path.join(dir))?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -18,7 +18,6 @@ impl Init {
 impl Command for Init {
     fn execute(&mut self) -> Result<(), RitError> {
         let git_path = self.git_path();
-        dbg!(&git_path);
 
         for dir in &["objects", "refs"] {
             fs::create_dir_all(git_path.join(dir))?;

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -18,6 +18,7 @@ impl Init {
 impl Command for Init {
     fn execute(&mut self) -> Result<(), RitError> {
         let git_path = self.git_path();
+        dbg!(&git_path);
 
         for dir in &["objects", "refs"] {
             fs::create_dir_all(git_path.join(dir))?;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,8 @@
-use crate::{errors::RitError, Session};
-use std::path::PathBuf;
+use crate::errors::RitError;
+use std::{
+    io::{self, Read},
+    path::PathBuf,
+};
 
 mod init;
 use init::Init;
@@ -9,6 +12,29 @@ use commit::Commit;
 
 mod add;
 use add::Add;
+
+#[derive(Clone, Debug)]
+pub struct Session {
+    pub name: String,
+    pub email: String,
+}
+
+impl Session {
+    pub fn new(name: Option<String>, email: Option<String>) -> Result<Self, RitError> {
+        let name = name.unwrap();
+        let email = email.unwrap();
+
+        Ok(Self { name, email })
+    }
+
+    pub fn read_stdin(&self) -> Result<String, RitError> {
+        let mut text = String::new();
+
+        io::stdin().read_to_string(&mut text)?;
+
+        Ok(text)
+    }
+}
 
 trait Command {
     fn execute(&mut self) -> Result<(), RitError>;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -37,6 +37,8 @@ impl Session {
 }
 
 trait Command {
+    fn new(opts: CommandOpts) -> Self;
+
     fn execute(&mut self) -> Result<(), RitError>;
 }
 
@@ -50,9 +52,9 @@ pub fn execute(mut opts: CommandOpts) -> Result<(), RitError> {
     let name = opts.args.remove(0);
 
     match &name[..] {
-        "init" => Init(opts).execute(),
-        "add" => Add(opts).execute(),
-        "commit" => Commit(opts).execute(),
+        "init" => Init::new(opts).execute(),
+        "add" => Add::new(opts).execute(),
+        "commit" => Commit::new(opts).execute(),
         _ => Err(RitError::UnknownCommand),
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,32 @@
+use crate::{errors::RitError, Session};
+use std::path::PathBuf;
+
+mod init;
+use init::Init;
+
+mod commit;
+use commit::Commit;
+
+mod add;
+use add::Add;
+
+trait Command {
+    fn execute(&mut self) -> Result<(), RitError>;
+}
+
+pub struct CommandOpts {
+    pub dir: PathBuf,
+    pub session: Session,
+    pub args: Vec<String>,
+}
+
+pub fn execute(mut opts: CommandOpts) -> Result<(), RitError> {
+    let name = opts.args.remove(0);
+
+    match &name[..] {
+        "init" => Init(opts).execute(),
+        "add" => Add(opts).execute(),
+        "commit" => Commit(opts).execute(),
+        _ => Err(RitError::UnknownCommand),
+    }
+}

--- a/src/database.rs
+++ b/src/database.rs
@@ -4,15 +4,15 @@ use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use std::{
     fs::{File, OpenOptions},
     io::{self, prelude::*},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
-pub struct Database<'a> {
-    path: &'a Path,
+pub struct Database {
+    path: PathBuf,
 }
 
-impl<'a> Database<'a> {
-    pub fn new(path: &'a Path) -> Self {
+impl Database {
+    pub fn new(path: PathBuf) -> Self {
         Self { path }
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,6 +10,7 @@ pub enum RitError {
     Refs(RefsError),
     MissingFile(String),
     PermissionDenied(String),
+    UnknownCommand,
 }
 
 impl fmt::Display for RitError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,21 @@
+mod objects;
+
+mod workspace;
+
+mod database;
+
+mod refs;
+
+pub mod lockfile;
+
+pub mod index;
+
+mod id;
+
+mod repository;
+
+mod commands;
+
+pub use commands::*;
+
+pub mod errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,16 +6,18 @@ mod database;
 
 mod refs;
 
-pub mod lockfile;
-
-pub mod index;
-
 mod id;
 
 mod repository;
 
 mod commands;
 
-pub use commands::*;
+pub mod lockfile;
+
+pub mod index;
 
 pub mod errors;
+
+pub use commands::*;
+
+pub use repository::Repository;

--- a/src/objects/commit.rs
+++ b/src/objects/commit.rs
@@ -8,12 +8,17 @@ use std::fmt;
 pub struct Commit<'a> {
     parent: &'a Option<String>,
     tree_id: Id,
-    author: Author,
+    author: Author<'a>,
     message: &'a str,
 }
 
 impl<'a> Commit<'a> {
-    pub fn new(parent: &'a Option<String>, tree_id: Id, author: Author, message: &'a str) -> Self {
+    pub fn new(
+        parent: &'a Option<String>,
+        tree_id: Id,
+        author: Author<'a>,
+        message: &'a str,
+    ) -> Self {
         Self {
             parent,
             tree_id,

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -46,14 +46,14 @@ pub trait Storable: Object {
     }
 }
 
-pub struct Author {
-    name: String,
-    email: String,
+pub struct Author<'a> {
+    name: &'a str,
+    email: &'a str,
     time: DateTime<Local>,
 }
 
-impl Author {
-    pub fn new(name: String, email: String) -> Self {
+impl<'a> Author<'a> {
+    pub fn new(name: &'a str, email: &'a str) -> Self {
         Self {
             name,
             email,
@@ -62,7 +62,7 @@ impl Author {
     }
 }
 
-impl fmt::Display for Author {
+impl<'a> fmt::Display for Author<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let timestamp = self.time.format("%s %z");
 

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -29,10 +29,10 @@ impl From<LockError> for RefsError {
     }
 }
 
-pub struct Refs<'a>(&'a PathBuf);
+pub struct Refs(PathBuf);
 
-impl<'a> Refs<'a> {
-    pub fn new(path: &'a PathBuf) -> Self {
+impl Refs {
+    pub fn new(path: PathBuf) -> Self {
         Self(path)
     }
 

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1,0 +1,20 @@
+use crate::{database::Database, index::Index, refs::Refs, workspace::Workspace};
+use std::path::PathBuf;
+
+pub struct Repository<'a> {
+    pub database: Database,
+    pub index: Index,
+    pub refs: Refs<'a>,
+    pub workspace: Workspace<'a>,
+}
+
+impl<'a> Repository<'a> {
+    pub fn new(git_path: &'a PathBuf) -> Self {
+        Self {
+            database: Database::new(git_path.join("objects")),
+            index: Index::new(git_path.join("index")),
+            refs: Refs::new(&git_path),
+            workspace: Workspace::new(&git_path),
+        }
+    }
+}

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1,20 +1,22 @@
 use crate::{database::Database, index::Index, refs::Refs, workspace::Workspace};
 use std::path::PathBuf;
 
-pub struct Repository<'a> {
+pub struct Repository {
     pub database: Database,
     pub index: Index,
-    pub refs: Refs<'a>,
-    pub workspace: Workspace<'a>,
+    pub refs: Refs,
+    pub workspace: Workspace,
 }
 
-impl<'a> Repository<'a> {
-    pub fn new(git_path: &'a PathBuf) -> Self {
+impl Repository {
+    pub fn new(project_path: PathBuf) -> Self {
+        let git_path = project_path.join(".git");
+
         Self {
-            database: Database::new(git_path.join("objects")),
-            index: Index::new(git_path.join("index")),
-            refs: Refs::new(&git_path),
-            workspace: Workspace::new(&git_path),
+            database: Database::new(git_path.clone().join("objects")),
+            index: Index::new(git_path.clone().join("index")),
+            refs: Refs::new(git_path),
+            workspace: Workspace::new(project_path),
         }
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -6,8 +6,8 @@ use std::{
     path::PathBuf,
 };
 
-pub struct Workspace<'a> {
-    path: &'a PathBuf,
+pub struct Workspace {
+    path: PathBuf,
 }
 
 #[derive(Debug, Clone)]
@@ -30,13 +30,13 @@ pub struct Stat {
     pub metadata: Metadata,
 }
 
-impl<'a> Workspace<'a> {
-    pub fn new(path: &'a PathBuf) -> Self {
+impl Workspace {
+    pub fn new(path: PathBuf) -> Self {
         Self { path }
     }
 
     pub fn list_files(&self, path: Option<&PathBuf>) -> Vec<PathBuf> {
-        let path = path.unwrap_or(self.path);
+        let path = path.unwrap_or(&self.path);
 
         if path.is_dir() {
             path.read_dir()

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -93,7 +93,7 @@ impl Workspace {
     }
 
     pub fn expand_path(&self, pathname: &str) -> Result<PathBuf, RitError> {
-        let path = fs::canonicalize(pathname);
+        let path = fs::canonicalize(&self.path.join(pathname));
 
         match path {
             Ok(path) => Ok(path),

--- a/tests/add_test.rs
+++ b/tests/add_test.rs
@@ -1,0 +1,139 @@
+use rit::{errors::RitError, index::IndexError};
+
+mod common;
+
+#[test]
+fn it_adds_regular_file_to_index() {
+    common::Project::open(|project| {
+        project.write_file("hello.txt", "hello");
+
+        project.cmd(vec!["add", "hello.txt"]).unwrap();
+
+        let expected_entries = vec![(project.expected_path("hello.txt"), 0o100644)];
+
+        assert_eq!(expected_entries, project.index_entries());
+    });
+}
+
+#[test]
+fn it_adds_executable_file_to_index() {
+    common::Project::open(|project| {
+        project.write_file("hello.txt", "hello");
+        project.make_executable("hello.txt");
+
+        project.cmd(vec!["add", "hello.txt"]).unwrap();
+
+        let expected_entries = vec![(project.expected_path("hello.txt"), 0o100755)];
+
+        assert_eq!(expected_entries, project.index_entries());
+    });
+}
+
+#[test]
+fn it_adds_multiple_files_to_index() {
+    common::Project::open(|project| {
+        project.write_file("hello.txt", "hello");
+        project.write_file("world.txt", "world");
+
+        project.cmd(vec!["add", "hello.txt", "world.txt"]).unwrap();
+
+        let expected_entries = vec![
+            (project.expected_path("hello.txt"), 0o100644),
+            (project.expected_path("world.txt"), 0o100644),
+        ];
+
+        assert_eq!(expected_entries, project.index_entries());
+    });
+}
+
+#[test]
+fn it_incrementally_adds_files_to_index() {
+    common::Project::open(|project| {
+        project.write_file("hello.txt", "hello");
+        project.write_file("world.txt", "world");
+
+        project.cmd(vec!["add", "world.txt"]).unwrap();
+
+        assert_eq!(
+            vec![(project.expected_path("world.txt"), 0o100644)],
+            project.index_entries()
+        );
+
+        project.cmd(vec!["add", "hello.txt"]).unwrap();
+
+        let expected_entries = vec![
+            (project.expected_path("hello.txt"), 0o100644),
+            (project.expected_path("world.txt"), 0o100644),
+        ];
+
+        assert_eq!(expected_entries, project.index_entries());
+    });
+}
+
+#[test]
+fn it_adds_directory_to_index() {
+    common::Project::open(|project| {
+        project.write_file("a-dir/nested.txt", "content");
+
+        project.cmd(vec!["add", "a-dir"]).unwrap();
+
+        assert_eq!(
+            vec![(project.expected_path("a-dir/nested.txt"), 0o100644)],
+            project.index_entries()
+        );
+    });
+}
+
+#[test]
+fn it_adds_repository_root_to_index() {
+    common::Project::open(|project| {
+        project.write_file("a/b/c/file.txt", "content");
+
+        project.cmd(vec!["add", "."]).unwrap();
+
+        assert_eq!(
+            vec![(project.expected_path("a/b/c/file.txt"), 0o100644)],
+            project.index_entries()
+        );
+    });
+}
+
+#[test]
+fn it_fails_for_nonexistent_file() {
+    common::Project::open(|project| {
+        match project.cmd(vec!["add", "no-such-file"]) {
+            Err(RitError::MissingFile(_)) => assert!(true),
+            _ => assert!(false, "MissingFile Err should be returned"),
+        };
+    });
+}
+
+#[test]
+fn it_fails_for_unreadable_file() {
+    common::Project::open(|project| {
+        project.write_file("secret.txt", "");
+        project.make_unreadable("secret.txt");
+
+        match project.cmd(vec!["add", "secret.txt"]) {
+            Err(RitError::PermissionDenied(_)) => assert!(true),
+            _ => {
+                assert!(false, "PermissionDenied Err should be returned");
+            }
+        };
+    });
+}
+
+#[test]
+fn it_fails_when_index_is_locked() {
+    common::Project::open(|project| {
+        project.write_file("file.txt", "");
+        project.write_file(".git/index.lock", "");
+
+        match project.cmd(vec!["add", "file.txt"]) {
+            Err(RitError::Index(IndexError::Lock(_))) => assert!(true),
+            _ => {
+                assert!(false, "Index Lock Err should be returned");
+            }
+        }
+    });
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,122 @@
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use rit::errors::RitError;
+use std::{
+    fs::{self, OpenOptions},
+    io::prelude::*,
+    os::unix::fs::PermissionsExt,
+    panic,
+    path::PathBuf,
+};
+
+pub struct Project {
+    pub dir: PathBuf,
+    session: rit::Session,
+}
+
+impl Project {
+    pub fn open<T>(test: T) -> ()
+    where
+        T: FnOnce(&Self) -> () + panic::UnwindSafe,
+    {
+        let project = Self::new();
+
+        let result = panic::catch_unwind(|| test(&project));
+
+        project.close();
+
+        assert!(result.is_ok())
+    }
+
+    fn get_dir() -> PathBuf {
+        let rng = thread_rng();
+        let s: String = rng.sample_iter(Alphanumeric).take(10).collect();
+
+        PathBuf::from(format!("./tests/testdir/tmp_dir_{}", s))
+    }
+
+    fn get_session() -> rit::Session {
+        let name = String::from("name");
+        let email = String::from("email");
+
+        rit::Session::new(Some(name), Some(email)).unwrap()
+    }
+
+    fn new() -> Self {
+        let dir = Self::get_dir();
+        let session = Self::get_session();
+
+        let args = vec!["init".to_string()];
+
+        rit::execute(rit::CommandOpts {
+            dir: dir.clone(),
+            session: session.clone(),
+            args,
+        })
+        .unwrap();
+
+        Self { dir, session }
+    }
+
+    pub fn cmd(&self, args: Vec<&str>) -> Result<(), RitError> {
+        rit::execute(rit::CommandOpts {
+            dir: self.dir.clone(),
+            session: self.session.clone(),
+            args: args.iter().map(|arg| arg.to_string()).collect(),
+        })
+    }
+
+    pub fn write_file(&self, name: &str, content: &str) {
+        let path = self.dir.join(name);
+        let prefix = path.parent().unwrap();
+        fs::create_dir_all(prefix).unwrap();
+
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+            .unwrap();
+
+        file.write_all(content.as_bytes()).unwrap();
+    }
+
+    pub fn index_entries(&self) -> Vec<(String, u32)> {
+        let mut repo = rit::Repository::new(self.dir.clone());
+        repo.index.load().unwrap();
+
+        repo.index
+            .entries()
+            .iter()
+            .map(|entry| (entry.pathname.clone(), entry.mode))
+            .collect()
+    }
+
+    pub fn expected_path(&self, name: &str) -> String {
+        format!(
+            "{}/{}",
+            self.dir.canonicalize().unwrap().to_str().unwrap(),
+            name
+        )
+        .to_string()
+    }
+
+    pub fn make_executable(&self, name: &str) {
+        self.set_file_mode(name, 0o755);
+    }
+
+    pub fn make_unreadable(&self, name: &str) {
+        self.set_file_mode(name, 0);
+    }
+
+    fn set_file_mode(&self, name: &str, mode: u32) {
+        let path = self.dir.join(name);
+        let mut perms = fs::metadata(&path).unwrap().permissions();
+
+        perms.set_mode(mode);
+
+        fs::set_permissions(path, perms).unwrap();
+    }
+
+    fn close(&self) {
+        fs::remove_dir_all(&self.dir).unwrap();
+    }
+}


### PR DESCRIPTION
* Refactor naive `argv` pattern matching into Command objects
* Move business logic to the `lib`
* Add integrations tests helper - `Project`
* Integration tests for the `Add` command